### PR TITLE
Fix: An exception was thrown when hassio called for an update and token was expired

### DIFF
--- a/panasonic_ac.py
+++ b/panasonic_ac.py
@@ -77,7 +77,12 @@ class PanasonicDevice(ClimateDevice):
  
     def update(self):
         """Update the state of this climate device."""
-        data= self._api.get_device(self._device['id'])
+        try:
+            data= self._api.get_device(self._device['id'])
+        except:
+            _LOGGER.debug("Error trying to get device {id} state, probably expired token, trying to update it...".format(**self._device))
+            self._api.login()
+            data = self._api.get_device(self._device['id'])
         
         if data is None:
             _LOGGER.debug("Received no data for device {id}".format(**self._device))


### PR DESCRIPTION
Hello,

I've noticed a bug where hassio throw an Exception on update when the token was expired or not valid anymore (eg. I logged in from the phone).
Basically i catch the exception and call login again before retrying to get the status of the device.
The problem with that is that, since hassio calls this function a lot, it appears that you get more often disconnected from the mobile app, and before this PR, you get disconnected only f you send an action from hassio
I don't think that this is a big issue since people that use this component will rarely use the panasonic app for controlling the AC, they'll do it from hassio, but it has to be taken into consideration in your choice to merge this or not. 

Thank you