### PR TITLE
Added necessary files for full HACS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This component uses the library `pcomfortcloud`
 https://github.com/lostfields/python-panasonic-comfort-cloud
 
 ## Usage
-- Copy `__init__.py`, `climate.py`, and `manifest.json` to the `custom_components/panasonic_ac/` folder. As an alternative, you can also install the component via the [Home Assistant Community Store (HACS)](https://custom-components.github.io/hacs/) by adding it manually.
-- Add the following configuration in `configuration.yml`:
+- Copy `__init__.py`, `climate.py`, and `manifest.json` to the `custom_components/panasonic_ac/` folder. As an alternative, you can also install the component via the [Home Assistant Community Store (HACS)](https://hacs.netlify.com/) by adding it manually.
+- Add the following configuration in `configuration.yaml`:
 
 ```yaml
 climate:

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Panasonic Comfort Cloud HA component",
   "domains": ["climate"],
-  "homeassistant": "0.96.0",
+  "homeassistant": "0.96.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Panasonic Comfort Cloud HA component",
+  "domains": ["climate"],
+  "homeassistant": "0.96.0",
+}

--- a/info.md
+++ b/info.md
@@ -1,0 +1,17 @@
+# Panasonic Comfort Cloud HA component
+
+A home assistant custom climate component to control Panasonic airconditioners and heatpumps.
+
+This component uses the library `pcomfortcloud`
+
+https://github.com/lostfields/python-panasonic-comfort-cloud
+
+## Usage
+Add the following configuration in `configuration.yaml`:
+
+```yaml
+climate:
+  - platform: panasonic_ac
+    username: !secret user
+    password: !secret password
+```


### PR DESCRIPTION
The structure of the project is already capable of HACS integration but these files makes it more in line with the documentation here https://hacs.netlify.com/developer/general/. Following this @djbulsink will have to submit a PR to HACS in accordance with the instructions here https://hacs.netlify.com/developer/include_default_repositories/ to have panasonic_ac included as a default HACS addon.