### PR TITLE
Fix Broken integrations

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.14"]
+  "requirements": ["pcomfortcloud==0.0.16"]
 }


### PR DESCRIPTION
A change has been made on the JSON format. Those change had been integrated into the latest PcomfortCloud pypi package, in 0.0.16.

Tested and working on my local installation with 2 different AC. 