### PR TITLE
Fix 403 forbidden issue

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.16"]
+  "requirements": ["pcomfortcloud==0.0.17"]
 }


### PR DESCRIPTION
Brings in the fix for 403 forbidden that is solved in #33 of the upstream pcomfortcloud package.