### PR TITLE
Bump requirements of pcomfortcloud fixing headers

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.23"],
+  "requirements": ["pcomfortcloud==0.0.24"],
   "version": "1.0.1"
 }


### PR DESCRIPTION
Moving from 0.0.23 to 0.0.24 fixing #41 