### PR TITLE
Bump to pcomfortcloud 0.0.25

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.24"],
+  "requirements": ["pcomfortcloud==0.0.25"],
   "version": "1.0.1"
 }


### PR DESCRIPTION
This should fix devices becoming unavailable as in https://github.com/djbulsink/panasonic_ac/issues/41 by including https://github.com/lostfields/python-panasonic-comfort-cloud/issues/82.