### PR TITLE
Bump pcomfortcloud to 26

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.25"],
+  "requirements": ["pcomfortcloud==0.0.26"],
   "version": "1.0.1"
 }


### PR DESCRIPTION
Bump to pcomfortcloud 0.0.26 dependency in mainfest
I have got pcomfortcloud updated to increment the app version, which currently is causing people to have to do a workaround in the HA core.  0.0.26 fixes that - release notes show only that change and also a bug fix 